### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-production-image.yml
+++ b/.github/workflows/publish-production-image.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@main
 
       - name: Publish Image
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: ghcr.io
           name: nfcopier/portfolio-repositories


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore